### PR TITLE
Refactor API to allow immediately return from handler chain

### DIFF
--- a/core/src/main/java/com/jinyframework/core/AbstractRequestBinder.java
+++ b/core/src/main/java/com/jinyframework/core/AbstractRequestBinder.java
@@ -204,11 +204,11 @@ public abstract class AbstractRequestBinder<T extends HandlerBase> {
         }
 
         public static <T> HttpResponse of(final T t) {
-            return new HttpResponse(200, t, true);
+            return new HttpResponse(200, t, false);
         }
 
         public static <T> HttpResponse of(final T t, final int httpStatusCode) {
-            return new HttpResponse(httpStatusCode, t, true);
+            return new HttpResponse(httpStatusCode, t, false);
         }
 
         public static CompletableFuture<HttpResponse> createPromise() {

--- a/core/src/test/java/com/jinyframework/HTTPServerTest.java
+++ b/core/src/test/java/com/jinyframework/HTTPServerTest.java
@@ -35,7 +35,7 @@ public class HTTPServerTest extends HTTPTest {
             server.useResponseHeaders(defaultResponseHeaders);
 
             server.get("/", ctx -> HttpResponse.of("Hello World"));
-            server.get("/immediate",ctx->HttpResponse.of("Foo"), ctx -> HttpResponse.of("Bar"));
+            server.get("/immediate", ctx -> HttpResponse.of("Foo"), ctx -> HttpResponse.of("Bar"));
             server.post("/transform", ctx -> HttpResponse.of(ctx.getBody()).transform(s -> s + "ed"));
             server.get("/gm", ctx -> HttpResponse.of(ctx.dataParam("global")));
             server.get("/gm-sub", ctx -> HttpResponse.of(ctx.dataParam("att")));

--- a/core/src/test/java/com/jinyframework/HTTPServerTest.java
+++ b/core/src/test/java/com/jinyframework/HTTPServerTest.java
@@ -35,6 +35,7 @@ public class HTTPServerTest extends HTTPTest {
             server.useResponseHeaders(defaultResponseHeaders);
 
             server.get("/", ctx -> HttpResponse.of("Hello World"));
+            server.get("/immediate",ctx->HttpResponse.of("Foo"), ctx -> HttpResponse.of("Bar"));
             server.post("/transform", ctx -> HttpResponse.of(ctx.getBody()).transform(s -> s + "ed"));
             server.get("/gm", ctx -> HttpResponse.of(ctx.dataParam("global")));
             server.get("/gm-sub", ctx -> HttpResponse.of(ctx.dataParam("att")));

--- a/core/src/test/java/com/jinyframework/HTTPTest.java
+++ b/core/src/test/java/com/jinyframework/HTTPTest.java
@@ -36,6 +36,15 @@ public abstract class HTTPTest {
     }
 
     @Test
+    @DisplayName("Immediately return from handler chain")
+    void immediateReturn() throws IOException {
+        val res = HttpClient.builder()
+                .url(url + "/immediate").method("GET")
+                .build().perform();
+        assertEquals(res.getBody(),"Foo");
+    }
+
+    @Test
     @DisplayName("Transformer")
     void transformer() throws IOException {
         val res = HttpClient.builder()

--- a/core/src/test/java/com/jinyframework/NIOHTTPServerTest.java
+++ b/core/src/test/java/com/jinyframework/NIOHTTPServerTest.java
@@ -35,6 +35,7 @@ public class NIOHTTPServerTest extends HTTPTest {
             server.useResponseHeaders(defaultResponseHeaders);
 
             server.get("/", ctx -> HttpResponse.ofAsync("Hello World"));
+            server.get("/immediate",ctx->HttpResponse.ofAsync("Foo"), ctx -> HttpResponse.ofAsync("Bar"));
             server.post("/transform", ctx -> HttpResponse.ofAsync(ctx.getBody(), s -> s + "ed"));
             server.get("/gm", ctx -> HttpResponse.ofAsync(ctx.dataParam("global")));
             server.get("/gm-sub", ctx -> HttpResponse.ofAsync(ctx.dataParam("att")));

--- a/core/src/test/java/com/jinyframework/NIOHTTPServerTest.java
+++ b/core/src/test/java/com/jinyframework/NIOHTTPServerTest.java
@@ -35,7 +35,7 @@ public class NIOHTTPServerTest extends HTTPTest {
             server.useResponseHeaders(defaultResponseHeaders);
 
             server.get("/", ctx -> HttpResponse.ofAsync("Hello World"));
-            server.get("/immediate",ctx->HttpResponse.ofAsync("Foo"), ctx -> HttpResponse.ofAsync("Bar"));
+            server.get("/immediate", ctx -> HttpResponse.ofAsync("Foo"), ctx -> HttpResponse.ofAsync("Bar"));
             server.post("/transform", ctx -> HttpResponse.ofAsync(ctx.getBody(), s -> s + "ed"));
             server.get("/gm", ctx -> HttpResponse.ofAsync(ctx.dataParam("global")));
             server.get("/gm-sub", ctx -> HttpResponse.ofAsync(ctx.dataParam("att")));

--- a/middlewares/src/main/java/com/jinyframework/middlewares/cors/Cors.java
+++ b/middlewares/src/main/java/com/jinyframework/middlewares/cors/Cors.java
@@ -1,22 +1,16 @@
 package com.jinyframework.middlewares.cors;
 
+import com.jinyframework.core.AbstractRequestBinder.Context;
+import com.jinyframework.core.AbstractRequestBinder.Handler;
+import com.jinyframework.core.AbstractRequestBinder.HttpResponse;
+import com.jinyframework.core.utils.ParserUtils.HttpMethod;
+import lombok.*;
+
 import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import com.jinyframework.core.AbstractRequestBinder.Context;
-import com.jinyframework.core.AbstractRequestBinder.Handler;
-import com.jinyframework.core.AbstractRequestBinder.HttpResponse;
-import com.jinyframework.core.utils.ParserUtils.HttpMethod;
-
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NonNull;
-import lombok.Singular;
-import lombok.val;
-import lombok.var;
 
 /**
  * Middleware to help handle Cross-Origin Resource Sharing


### PR DESCRIPTION
If the handler chain is allowed to continue, HttpResponse.next() should be called instead. Calling HttpResponse.of() is expected to end the chain so that the results specified is the final response.