### PR TITLE
Handler path case sensitive

### DIFF
--- a/core/src/main/java/com/jinyframework/core/utils/ParserUtils.java
+++ b/core/src/main/java/com/jinyframework/core/utils/ParserUtils.java
@@ -54,7 +54,7 @@ public final class ParserUtils {
             }
         }
 
-        val path = metaArr.length >= 2 ? metaArr[1].toLowerCase() : "";
+        val path = metaArr.length >= 2 ? metaArr[1] : "";
 
         val indexOfQuestionMark = path.indexOf('?');
         val queryParamsString = indexOfQuestionMark == -1 ? null : path.substring(indexOfQuestionMark + 1);

--- a/core/src/test/java/com/jinyframework/HTTPServerTest.java
+++ b/core/src/test/java/com/jinyframework/HTTPServerTest.java
@@ -98,6 +98,9 @@ public class HTTPServerTest extends HTTPTest {
                 throw new RuntimeException("Panicked!");
             });
 
+            server.get("/hasCase",ctx -> HttpResponse.of("hasCase"));
+            server.get("/noncase",ctx -> HttpResponse.of("noncase"));
+
             val catRouter = new HttpRouter();
             catRouter.use(ctx -> {
                 ctx.getData().put("att", "cat");

--- a/core/src/test/java/com/jinyframework/HTTPTest.java
+++ b/core/src/test/java/com/jinyframework/HTTPTest.java
@@ -152,6 +152,27 @@ public abstract class HTTPTest {
     }
 
     @Test
+    @DisplayName("Path case")
+    void pathCase() throws IOException {
+        val hasOk = HttpClient.builder()
+                .url(url + "/hasCase").method("GET")
+                .build().perform();
+        assertEquals(200,hasOk.getStatus());
+        val hasFail = HttpClient.builder()
+                .url(url + "/hascase").method("GET")
+                .build().perform();
+        assertEquals(404,hasFail.getStatus());
+        val nonOk = HttpClient.builder()
+                .url(url + "/noncase").method("GET")
+                .build().perform();
+        assertEquals(200,nonOk.getStatus());
+        val nonFail = HttpClient.builder()
+                .url(url + "/nonCase").method("GET")
+                .build().perform();
+        assertEquals(404,nonFail.getStatus());
+    }
+
+    @Test
     @DisplayName("Global Middleware")
     void globalMiddleware() throws IOException {
         val res = HttpClient.builder()

--- a/core/src/test/java/com/jinyframework/NIOHTTPServerTest.java
+++ b/core/src/test/java/com/jinyframework/NIOHTTPServerTest.java
@@ -98,6 +98,9 @@ public class NIOHTTPServerTest extends HTTPTest {
                 throw new RuntimeException("Panicked!");
             });
 
+            server.get("/hasCase",ctx -> HttpResponse.ofAsync("hasCase"));
+            server.get("/noncase",ctx -> HttpResponse.ofAsync("noncase"));
+
             val catRouter = new HttpRouterNIO();
             catRouter.use(ctx -> {
                 ctx.setDataParam("att", "cat");


### PR DESCRIPTION
Fixes #31 
- Remove "toLowerCase" in parse util when processing handler path
- Add tests