### PR TITLE
[Keva] naive periodic snapshot implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ gradle.properties
 testproject/
 run.sh
 config.json
+dump.keva

--- a/core/src/test/java/com/jinyframework/HttpProxyTest.java
+++ b/core/src/test/java/com/jinyframework/HttpProxyTest.java
@@ -36,8 +36,8 @@ public class HttpProxyTest {
         proxy.use("/nio", "localhost:2222");
         new Thread(proxy::start).start();
 
-        // Wait for server to start
-        TimeUnit.SECONDS.sleep(1);
+        // Wait for all server to start
+        TimeUnit.SECONDS.sleep(2);
     }
 
     @Test

--- a/core/src/test/java/com/jinyframework/HttpProxyTest.java
+++ b/core/src/test/java/com/jinyframework/HttpProxyTest.java
@@ -36,7 +36,7 @@ public class HttpProxyTest {
         proxy.use("/nio", "localhost:2222");
         new Thread(proxy::start).start();
 
-        // Wait for all server to start
+        // Wait for all servers  to start
         TimeUnit.SECONDS.sleep(2);
     }
 

--- a/keva/server/src/main/java/com/jinyframework/keva/server/Application.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/Application.java
@@ -1,6 +1,7 @@
 package com.jinyframework.keva.server;
 
 import com.jinyframework.keva.server.core.Server;
+import com.jinyframework.keva.server.core.SnapshotConfig;
 import com.jinyframework.keva.server.util.ArgsParser;
 import lombok.extern.slf4j.Slf4j;
 import lombok.val;
@@ -18,6 +19,8 @@ public final class Application {
         options.add("h");
         options.add("p");
         options.add("ht");
+        options.add("rc");
+        options.add("sn");
         return ArgsParser.parse(args, options);
     }
 
@@ -28,11 +31,19 @@ public final class Application {
             val hostname = config.getOrDefault("h", "localhost");
             val port = Integer.parseInt(config.getOrDefault("p", "6767"));
             val heartbeatTimeout = Integer.parseInt(config.getOrDefault("ht", "60000"));
+            val recoveryPath = config.getOrDefault("rc", "./dump.keva");
+            val snapInterval = config.getOrDefault("sn", "PT2M");
+
+            val snapConfig = SnapshotConfig.builder()
+                    .recoveryPath(recoveryPath)
+                    .snapshotInterval(snapInterval)
+                    .build();
 
             val server = Server.builder()
                     .host(hostname)
                     .port(port)
                     .heartbeatTimeout(heartbeatTimeout)
+                    .snapshotConfig(snapConfig)
                     .build();
 
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {

--- a/keva/server/src/main/java/com/jinyframework/keva/server/ServiceFactory.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/ServiceFactory.java
@@ -4,6 +4,8 @@ import com.jinyframework.keva.server.command.CommandService;
 import com.jinyframework.keva.server.command.CommandServiceImpl;
 import com.jinyframework.keva.server.core.ConnectionService;
 import com.jinyframework.keva.server.core.ConnectionServiceImpl;
+import com.jinyframework.keva.server.core.SnapShotServiceImpl;
+import com.jinyframework.keva.server.core.SnapshotService;
 
 public final class ServiceFactory {
     private ServiceFactory() {
@@ -17,11 +19,19 @@ public final class ServiceFactory {
         return CommandServiceHolder.commandService;
     }
 
-    private static final class CommandServiceHolder {
-        static final CommandService commandService = new CommandServiceImpl();
+    public static SnapshotService snapshotService() {
+        return SnapshotServiceHolder.snapshotService;
     }
 
     private static final class ConnectionServiceHolder {
         static final ConnectionService connectionService = new ConnectionServiceImpl();
+    }
+
+    private static final class CommandServiceHolder {
+        static final CommandService commandService = new CommandServiceImpl();
+    }
+
+    private static final class SnapshotServiceHolder {
+        static final SnapshotService snapshotService = new SnapShotServiceImpl();
     }
 }

--- a/keva/server/src/main/java/com/jinyframework/keva/server/core/Server.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/core/Server.java
@@ -60,6 +60,10 @@ public class Server {
     }
 
     private void startSnapshot() {
+        if (snapshotConfig == null) {
+            return;
+        }
+
         val recoveryPath = snapshotConfig.getRecoveryPath();
         if (recoveryPath != null && !recoveryPath.isEmpty()) {
             snapshotService().recover(recoveryPath);

--- a/keva/server/src/main/java/com/jinyframework/keva/server/core/Server.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/core/Server.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketTimeoutException;
+import java.time.Duration;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -16,6 +17,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static com.jinyframework.keva.server.ServiceFactory.connectionService;
+import static com.jinyframework.keva.server.ServiceFactory.snapshotService;
 
 @Slf4j
 @Builder
@@ -28,11 +30,12 @@ public class Server {
 
     private final String host;
     private final int port;
+    private final SnapshotConfig snapshotConfig;
     private long heartbeatTimeout;
     private ServerSocket serverSocket;
     private ExecutorService executor;
 
-    private void init() throws IOException {
+    private void startServer() throws IOException {
         executor = Executors.newCachedThreadPool();
         val socketAddress = new InetSocketAddress(host, port);
         if (serverSocket == null) {
@@ -56,9 +59,22 @@ public class Server {
         log.info("Heartbeat service started");
     }
 
+    private void startSnapshot() {
+        val recoveryPath = snapshotConfig.getRecoveryPath();
+        if (recoveryPath != null && !recoveryPath.isEmpty()) {
+            snapshotService().recover(recoveryPath);
+        }
+
+        val snapIntervalDur = Duration.parse(snapshotConfig.getSnapshotInterval());
+        if (snapIntervalDur.toMillis() > 0) {
+            snapshotService().start(snapIntervalDur);
+        }
+    }
+
     public void run() throws IOException {
-        init();
+        startServer();
         startHeartbeat();
+        startSnapshot();
         while (!serverStopping.get()) {
             try {
                 val socket = serverSocket.accept();

--- a/keva/server/src/main/java/com/jinyframework/keva/server/core/Server.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/core/Server.java
@@ -82,6 +82,10 @@ public class Server {
         while (!serverStopping.get()) {
             try {
                 val socket = serverSocket.accept();
+                if (serverStopping.get()) {
+                    socket.close();
+                    break;
+                }
                 executor.execute(() -> {
                     val kevaSocket = KevaSocket.builder()
                             .socket(socket)

--- a/keva/server/src/main/java/com/jinyframework/keva/server/core/SnapShotServiceImpl.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/core/SnapShotServiceImpl.java
@@ -1,0 +1,74 @@
+package com.jinyframework.keva.server.core;
+
+import lombok.Cleanup;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+
+import java.io.*;
+import java.nio.file.Paths;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.jinyframework.keva.server.storage.StorageFactory.hashStore;
+
+@Slf4j
+public class SnapShotServiceImpl implements SnapshotService {
+    public static final String snapFileName = "dump.keva";
+    private final Map<String, String> hashStore = hashStore();
+
+    @Override
+    public void start(Duration interval, String fileDir) {
+        if (fileDir == null || fileDir.isEmpty()) {
+            fileDir = ".";
+        }
+        val finalFileDir = fileDir;
+        final Runnable runnable = () -> {
+            log.info("Saving snapshot");
+            val entrySetCopy = new HashMap<>(hashStore).entrySet();
+            try {
+                val snapFilePath = Paths.get(finalFileDir, snapFileName);
+                @Cleanup
+                val fileOut = new FileOutputStream(snapFilePath.toString());
+                @Cleanup
+                val objOutStream = new ObjectOutputStream(fileOut);
+
+                val snapMap = entrySetCopy.stream()
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                objOutStream.writeObject(snapMap);
+            } catch (IOException e) {
+                log.error("Failed to save snapshot:", e);
+            }
+            log.info("Saved snapshot");
+        };
+        val scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+        scheduledExecutor.scheduleAtFixedRate(runnable,
+                interval.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
+        log.info("Snapshot service started");
+    }
+
+    @Override
+    public void start(Duration interval) {
+        start(interval, "./");
+    }
+
+    @Override
+    public void recover(String snapFilePath) {
+        log.info("Recovering hash map from file");
+        try {
+            @Cleanup
+            val fileIn = new FileInputStream(snapFilePath);
+            @Cleanup
+            val objInStream = new ObjectInputStream(fileIn);
+
+            val snapMap = (HashMap<String, String>) objInStream.readObject();
+            hashStore.putAll(snapMap);
+        } catch (Exception e) {
+            log.error("Failed to recover from snapshot:", e);
+        }
+        log.info("Recovery finished");
+    }
+}

--- a/keva/server/src/main/java/com/jinyframework/keva/server/core/SnapShotServiceImpl.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/core/SnapShotServiceImpl.java
@@ -57,6 +57,9 @@ public class SnapShotServiceImpl implements SnapshotService {
 
     @Override
     public void recover(String snapFilePath) {
+        if (snapFilePath == null || snapFilePath.isEmpty()) {
+            snapFilePath = Paths.get(".", snapFileName).toString();
+        }
         log.info("Recovering hash map from file");
         try {
             @Cleanup

--- a/keva/server/src/main/java/com/jinyframework/keva/server/core/SnapshotConfig.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/core/SnapshotConfig.java
@@ -1,0 +1,13 @@
+package com.jinyframework.keva.server.core;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@Setter
+public class SnapshotConfig {
+    private final String snapshotInterval;
+    private final String recoveryPath;
+}

--- a/keva/server/src/main/java/com/jinyframework/keva/server/core/SnapshotService.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/core/SnapshotService.java
@@ -1,0 +1,11 @@
+package com.jinyframework.keva.server.core;
+
+import java.time.Duration;
+
+public interface SnapshotService {
+    void start(Duration interval, String fileDir);
+
+    void start(Duration interval);
+
+    void recover(String fileDir);
+}

--- a/keva/server/src/main/java/com/jinyframework/keva/server/util/PortUtil.java
+++ b/keva/server/src/main/java/com/jinyframework/keva/server/util/PortUtil.java
@@ -1,0 +1,19 @@
+package com.jinyframework.keva.server.util;
+
+import lombok.SneakyThrows;
+import lombok.val;
+
+import java.net.ServerSocket;
+
+public final class PortUtil {
+    private PortUtil() {
+    }
+
+    @SneakyThrows
+    public static int getAvailablePort() {
+        val serverSocket = new ServerSocket(0);
+        val port = serverSocket.getLocalPort();
+        serverSocket.close();
+        return port;
+    }
+}

--- a/keva/server/src/test/java/com/jinyframework/keva/server/HeartbeatServiceTest.java
+++ b/keva/server/src/test/java/com/jinyframework/keva/server/HeartbeatServiceTest.java
@@ -1,0 +1,95 @@
+package com.jinyframework.keva.server;
+
+import com.jinyframework.keva.server.core.Server;
+import com.jinyframework.keva.server.util.PortUtil;
+import com.jinyframework.keva.server.util.SocketClient;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import lombok.var;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+public class HeartbeatServiceTest {
+    static String host = "localhost";
+    static int port = PortUtil.getAvailablePort();
+    static Server server;
+    static long heartbeatTimeout = 500;
+
+    @BeforeAll
+    static void startServer() throws Exception {
+        server = Server.builder()
+                .host(host)
+                .port(port)
+                .heartbeatTimeout(heartbeatTimeout)
+                .build();
+        new Thread(() -> {
+            try {
+                server.run();
+            } catch (Exception e) {
+                fail(e);
+            }
+        }).start();
+
+        // Wait for server to start
+        TimeUnit.SECONDS.sleep(1);
+
+    }
+
+    @AfterAll
+    static void stop() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    void alive() {
+        val client = new SocketClient(host, port);
+        try {
+            client.connect();
+
+            var pong = client.exchange("ping");
+            assertEquals("PONG", pong);
+            TimeUnit.MILLISECONDS.sleep(100);
+            pong = client.exchange("ping");
+            assertEquals("PONG", pong);
+            TimeUnit.MILLISECONDS.sleep(300);
+            pong = client.exchange("ping");
+            assertEquals("PONG", pong);
+        } catch (Exception e) {
+            fail(e);
+        }
+        client.disconnect();
+    }
+
+    @Test
+    void timeout() {
+        val client = new SocketClient(host, port);
+        try {
+            client.connect();
+
+            var pong = client.exchange("ping");
+            pong = client.exchange("ping");
+            assertEquals("PONG", pong);
+
+            // wait for timeout
+            TimeUnit.MILLISECONDS.sleep(heartbeatTimeout);
+
+            // wait for next heartbeat cycle to run
+            TimeUnit.MILLISECONDS.sleep(heartbeatTimeout / 2);
+
+            // wait for it to finish running
+            TimeUnit.MILLISECONDS.sleep(100);
+
+            pong = client.exchange("ping");
+            assertNull(pong);
+        } catch (Exception e) {
+            fail(e);
+        }
+        client.disconnect();
+    }
+}

--- a/keva/server/src/test/java/com/jinyframework/keva/server/SnapshotServiceTest.java
+++ b/keva/server/src/test/java/com/jinyframework/keva/server/SnapshotServiceTest.java
@@ -48,9 +48,11 @@ public class SnapshotServiceTest {
 
     void deleteFile(String filePath) {
         val f = new File(filePath);
-        val delete = f.delete();
-        if (!delete) {
-            fail("Delete dump file failed");
+        if (f.exists()) {
+            val delete = f.delete();
+            if (!delete) {
+                fail("Delete dump file failed");
+            }
         }
     }
 

--- a/keva/server/src/test/java/com/jinyframework/keva/server/SnapshotServiceTest.java
+++ b/keva/server/src/test/java/com/jinyframework/keva/server/SnapshotServiceTest.java
@@ -39,7 +39,6 @@ public class SnapshotServiceTest {
         // Wait for server to start
         TimeUnit.SECONDS.sleep(1);
         return server;
-
     }
 
     void stop(Server server) throws Exception {
@@ -132,5 +131,4 @@ public class SnapshotServiceTest {
             fail(e);
         }
     }
-
 }

--- a/keva/server/src/test/java/com/jinyframework/keva/server/SnapshotServiceTest.java
+++ b/keva/server/src/test/java/com/jinyframework/keva/server/SnapshotServiceTest.java
@@ -1,0 +1,134 @@
+package com.jinyframework.keva.server;
+
+import com.jinyframework.keva.server.core.Server;
+import com.jinyframework.keva.server.core.SnapshotConfig;
+import com.jinyframework.keva.server.util.SocketClient;
+import lombok.val;
+import lombok.var;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.util.concurrent.TimeUnit;
+
+import static com.jinyframework.keva.server.util.PortUtil.getAvailablePort;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class SnapshotServiceTest {
+    static String host = "localhost";
+    static String snapInterval = "PT2S";
+
+    Server startServer(int port) throws Exception {
+        val snapshotConfig = SnapshotConfig.builder()
+                .snapshotInterval(snapInterval)
+                .recoveryPath("./dump.keva")
+                .build();
+        val server = Server.builder()
+                .host(host)
+                .port(port)
+                .snapshotConfig(snapshotConfig)
+                .build();
+        new Thread(() -> {
+            try {
+                server.run();
+            } catch (Exception e) {
+                fail(e);
+            }
+        }).start();
+
+        // Wait for server to start
+        TimeUnit.SECONDS.sleep(1);
+        return server;
+
+    }
+
+    void stop(Server server) throws Exception {
+        server.shutdown();
+    }
+
+    void deleteFile(String filePath) {
+        val f = new File(filePath);
+        val delete = f.delete();
+        if (!delete) {
+            fail("Delete dump file failed");
+        }
+    }
+
+    @Test
+    void save() {
+        sync(getAvailablePort());
+    }
+
+    void sync(int port) {
+        deleteFile("./dump.keva");
+        Server server = null;
+        try {
+            server = startServer(port);
+        } catch (Exception e) {
+            fail(e);
+        }
+        val client = new SocketClient(host, port);
+        try {
+            client.connect();
+
+            var success = client.exchange("set a b");
+            assertEquals("1", success);
+            success = client.exchange("set b c");
+            assertEquals("1", success);
+            success = client.exchange("set c d");
+            assertEquals("1", success);
+
+            // Wait for snap service to start
+            TimeUnit.SECONDS.sleep(2);
+            // Wait for snap service to finish
+            TimeUnit.MILLISECONDS.sleep(100);
+
+            val fileInputStream = new FileInputStream("./dump.keva");
+            val available = fileInputStream.available();
+            assertTrue(available > 0);
+        } catch (Exception e) {
+            fail(e);
+        }
+        client.disconnect();
+        try {
+            stop(server);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+    @Test
+    void recover() {
+        sync(getAvailablePort());
+
+        val port = getAvailablePort();
+        Server server = null;
+        try {
+            server = startServer(port);
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        val client = new SocketClient(host, port);
+        try {
+            client.connect();
+
+            var success = client.exchange("get a");
+            assertEquals("b", success);
+            success = client.exchange("get b");
+            assertEquals("c", success);
+            success = client.exchange("get c");
+            assertEquals("d", success);
+        } catch (Exception e) {
+            fail(e);
+        }
+
+        client.disconnect();
+        try {
+            stop(server);
+        } catch (Exception e) {
+            fail(e);
+        }
+    }
+
+}


### PR DESCRIPTION
- Periodically serialize a snapshot of the hash map (option: "sn")
- Uses ISO 8601 duration format for interval
- Recover hash map from a dump file (option: "rc")
- Default snapshot location and recovery file lookup : "./dump.keva"

- Snapshot + recovery usage:
```
keva -sn {snapshot interval} -rc {dump file path}
```
*"keva" refers to your specific execution script, it could be ```jar -jar keva.jar``` or ```gradle keva:server:run```
- Example:
```
# Server will take snapshot every 5 minutes
keva -sn PT5M -rc './dump.keva'
```

TODO:
- Add snapshot file location option
- Update docs on behavior